### PR TITLE
fixing typo, minor workflow tweaks

### DIFF
--- a/.github/workflows/build-push-image-commit.yaml
+++ b/.github/workflows/build-push-image-commit.yaml
@@ -14,11 +14,6 @@ jobs:
       image-tag: ${{ steps.build-and-push.outputs.IMAGE_SHA_TAG }}
 
     steps:
-      - name: Cleanup disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          df -h
-
       - name: Check out the image repo
         uses: actions/checkout@v4
         with:
@@ -34,6 +29,12 @@ jobs:
             LICENSE
             .github/**
             images/**
+
+      - name: Cleanup disk space
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h
 
       - name: Log in to GAR
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -81,7 +82,6 @@ jobs:
           repository: 'berkeley-dsep-infra/datahub'
           sparse-checkout: |
             deployments/
-            hub/
   
       - name: Set git identity
         if: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -9,11 +9,6 @@ jobs:
     env:
       DOCKER_CONFIG: $HOME/.docker
     steps:
-      - name: cleanup disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          df -h
-
       - name: Checkout files in repo
         uses: actions/checkout@v4
 
@@ -28,13 +23,11 @@ jobs:
             .github/**
             images/**
 
-      - name: What files changed?
+      - name: Cleanup disk space
         if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-            CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-            echo "One or more image file(s) has changed:"
-            echo "$CHANGED_FILES"
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h
 
       - name: Build and test the image if any image file(s) changed
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,26 @@ git checkout -b <branch name>
 After you make your changes, you can use the following commands to see
 what's been modified and check out the diffs:  `git status` and `git diff`.
 
+### Building the image locally
+
+You should use [repo2docker](https://repo2docker.readthedocs.io/en/latest/) to build and use/test the image on your own device before you push and create a PR.  It's better (and typically faster) to do this first before using CI/CD.  There's no need to waste Github Action minutes to test build images when you can do this on your own device!
+
+Run `repo2docker` from inside the cloned image repo.  To run on a linux/WSL2 linux shell:
+```
+repo2docker . # <--- the path to the repo
+```
+
+If you are using an ARM CPU (Apple M* silicon), you will need to run `jupyter-repo2docker` with the following arguments:
+
+```
+jupyter-repo2docker --user-id=1000 --user-name=jovyan \
+  --Repo2Docker.platform=linux/amd64 \
+  --target-repo-dir=/home/jovyan/.cache \
+  -e PLAYWRIGHT_BROWSERS_PATH=/srv/conda \
+  . # <--- the path to the repo
+```
+
+If you just want to see if the image builds, but not automatically launch the server, add `--no-run` to the arguments (before the final `.`).
 
 When you're ready to push these changes, first you'll need to stage them for a
 commit:


### PR DESCRIPTION

in CONTRIBUTING.md, s/repo2-docker/repo2docker/g

in the build workflows, we should only cleanup disk space if we're going to build the image... this usually takes ~15sec to run, so it'll save us a bit of time when changes to the docs are pushed and the image isn't built.