### PR TITLE
Add JupyterLab notifications to a11y hub image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 # Install Code Server to test codeserver specific a11y extensions
 - jupyter-vscode-proxy==0.6
 - code-server==4.23.1
+- jupyterlab-notifications==0.5.0
 - pip:
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693


### PR DESCRIPTION
Interns are planning to use this package for their testing of a feature in jupyterlab-a11y-checker extension!