### PR TITLE
Bump jupyterlab-a11y-checker to the latest version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,6 @@ dependencies:
   - nbconvert-a11y==2024.03.25
   - nb2pdf==0.6.2
   - nbpdfexport==0.2.1
-  - jupyterlab-a11y-checker==0.1.2
+  - jupyterlab-a11y-checker==0.1.3
   # pulled in by ottr, if not pinned to 1.16.2, 1.16.3 causes DH-323
   - jupytext==1.16.2


### PR DESCRIPTION
This version bump brings in the security update provided by dependabot alert - https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker/pull/19