### PR TITLE
Add latest alpha version of a11y-checker extension for testing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,6 @@ dependencies:
   - nbconvert-a11y==2024.03.25
   - nb2pdf==0.6.2
   - nbpdfexport==0.2.1
-  - jupyterlab-a11y-checker==0.1.3
+  - jupyterlab-a11y-checker==0.1.4a0
   # pulled in by ottr, if not pinned to 1.16.2, 1.16.3 causes DH-323
   - jupytext==1.16.2


### PR DESCRIPTION
This version will generate alt-text for images added in a notebook cell. Testing it in a11y hub.