### PR TITLE
Use .dockerignore to ignore files.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.github
+
+CONTRIBUTING.md
+LICENSE
+README.md
+
+images

--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - '.github/**'
-      - 'images/**'
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -2,12 +2,6 @@ name: Build and test container image
 
 on:
   pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - '.github/**'
-      - 'images/**'
 
 jobs:
   test-build:


### PR DESCRIPTION
a11y-user-image has branch protection, which is why it waits on ignored actions to complete.