### PR TITLE
Add the latest version of jupyterlab-a11y-checker for testing in a11y hub!

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,6 +56,4 @@ dependencies:
     - nbconvert-a11y==2024.03.25
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1
-    - jupyterlab-a11y-checker==0.1.4a2
-
-
+    - jupyterlab-a11y-checker==0.1.5a0


### PR DESCRIPTION
It has the latest changes to check for a11y issues in a jupyter notebook using axe deque and also provide suggestions to fix some of the issues using mistral model from Ollama.