### PR TITLE
Bump a11y-checker extension to 0.2.2 version (latest)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,4 +56,4 @@ dependencies:
     - nbconvert-a11y==2024.03.25
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1
-    - jupyterlab-a11y-checker==0.2.1
+    - jupyterlab-a11y-checker==0.2.2


### PR DESCRIPTION
New release with few bug fixes - https://pypi.org/project/jupyterlab-a11y-checker/0.2.2/