### PR TITLE
[DH-635] Bump nbgitpuller to the latest beta version release in a11y hub

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,13 +18,12 @@ dependencies:
   - jupyterlab-git==0.50.2
   - jupyterlab_rise==0.43.1
   - jupytext==1.16.6
-  - nbgitpuller==1.2.1
   - notebook==7.5.0
   - otter-grader==6.1.0
   - pip==24.3.1  
 
   # otherstuff
-  - coverage==7.2.2
+  - coverage==7.13.3
   - jupyter-book==0.15.1
   - matplotlib==3.10.7
   - nbclassic==1.0.0
@@ -50,6 +49,7 @@ dependencies:
     # required
     - nbconvert[webpdf]==7.16.5
     - git-credential-helpers==0.2
+    - nbgitpuller==1.3.0b1
 
     # otherstuff
     # Upgrade separate from what everyone else uses for now


### PR DESCRIPTION
Even though https://jupyter.cal-icor.org/ has the latest version for testing purposes, since I built the a11y image locally, it doesn't hurt to update the repo.